### PR TITLE
Added support for other OpenGraph like tags

### DIFF
--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -90,18 +90,20 @@ class OpenGraph(dict):
             if self.scrape and not self.is_valid():
                 for attr in self.providers.get(
                     self.provider, {}
-                ).get('required_attrs'):
+                ).get('required_attrs', []):
                     if not hasattr(self, attr):
                         try:
                             self[attr] = getattr(self, 'scrape_%s' % attr)(doc)
                         except AttributeError:
                             pass
+        else:
+            self.provider = 'og'
 
     def is_valid(self):
         return all([
             hasattr(self, attr) for attr in self.providers.get(
                 self.provider, {}
-            ).get('required_attrs')
+            ).get('required_attrs', [])
         ])
 
     def to_html(self):


### PR DESCRIPTION
Twitter and OpenGraph have been split apart.  I made all attempts to respect OpenGraph as the default provider, while allowing either to be used very easily.

Each 'Provider' can have different required attributes, as well as the attribute we key off of for finding these tags.

Passing **provider** to OpenGraph() will force a Provider. If any OpenGraph tags are found, OpenGraph becomes the Provider, which forces validity of OpenGraph instead of the original Provider.

is_valid() has been modified such that it will use the detected Provider.  If tags of mixed providers are found, OpenGraph will take precedence.

to_html() has been altered to print using the Provider's name.

OrderedDict from collections is used to keep OpenGraph as top priority.
