### PR TITLE
replace urllib2 by requests

### DIFF
--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 import re
-import urllib2
+import requests
 try:
     from bs4 import BeautifulSoup
 except ImportError:
@@ -48,7 +48,7 @@ class OpenGraph(dict):
         """
         """
         raw = urllib2.urlopen(url)
-        html = raw.read()
+        html = raw.text
         return self.parser(html)
         
     def parser(self, html):

--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -47,7 +47,7 @@ class OpenGraph(dict):
     def fetch(self, url):
         """
         """
-        raw = urllib2.urlopen(url)
+        raw = requests.get(url)
         html = raw.text
         return self.parser(html)
         

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(name='opengraph',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-          'beautifulsoup4'
+          'beautifulsoup4',
+          'requests'
       ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
Hi,
I use python python 2.7.9 and it will an error, and I found it may due to SSL verification in Python 2.7.9 from some discussion https://github.com/HenriWahl/Nagstamon/issues/126#issuecomment-67765841.

I replace urllib2 by requests to make sure it works in python2.7 in this PR.

Traceback (most recent call last):
  File "./og.py", line 5, in <module>
    video = opengraph.OpenGraph(url="http://www.youtube.com/watch?v=q3ixBmDzylQ")
  File "/usr/local/lib/python2.7/site-packages/opengraph/opengraph.py", line 36, in __init__
    self.fetch(url)
  File "/usr/local/lib/python2.7/site-packages/opengraph/opengraph.py", line 50, in fetch
    raw = urllib2.urlopen(url)
  File "/usr/local/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/lib/python2.7/urllib2.py", line 437, in open
    response = meth(req, response)
  File "/usr/local/lib/python2.7/urllib2.py", line 550, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/lib/python2.7/urllib2.py", line 469, in error
    result = self._call_chain(*args)
  File "/usr/local/lib/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python2.7/urllib2.py", line 656, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/local/lib/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/usr/local/lib/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/usr/local/lib/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python2.7/urllib2.py", line 1240, in https_open
    context=self._context)
  File "/usr/local/lib/python2.7/urllib2.py", line 1197, in do_open
    raise URLError(err)
urllib2.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:581)>
