### PR TITLE
Fix malformed json error message

### DIFF
--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -97,7 +97,7 @@ class OpenGraph(dict):
         # TODO: force unicode
         global import_json
         if not import_json:
-            return "{'error':'there isn't json module'}"
+            return '{"error":"missing json module"}'
 
         if not self.is_valid():
             return json.dumps({'error':'og metadata is not valid'})


### PR DESCRIPTION
This is a valid Python string, but the json is incorrect.
See [json spec](https://www.json.org/):
> A string is a sequence of zero or more Unicode characters, wrapped in double quotes [...]

For "simplicity" I'm creating the Python string in single quotes, arguing that the codebase already uses a mixed double- and single quoting style, anyway.

Update: Probably not necessary if https://github.com/erikriver/opengraph/pull/4/files get's merged.