### PR TITLE
specify a dummy user agent

### DIFF
--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -52,7 +52,8 @@ class OpenGraph(dict):
     def fetch(self, url):
         """
         """
-        raw = urllib2.urlopen(url)
+        request = urllib2.Request(url, headers={"User-Agent" : "Mozilla"})
+        raw = urllib2.urlopen(req, timeout=15)
         html = raw.read()
         return self.parser(html)
 


### PR DESCRIPTION
Some websites block access from scripts to avoid 'unnecessary' usage of their servers by reading the headers urllib sends and thus results in 403 error when fetching data. 
this PR adds a dummy one