### PR TITLE
According to http://ogp.me/ description is not required.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Usage
    ... """
    >>> movie = opengraph.OpenGraph() # or you can instantiate as follows: opengraph.OpenGraph(html=HTML)
    >>> movie.parser(HTML)
-   >>> video.is_valid()
+   >>> movie.is_valid()
    True
 
 **Generate JSON or HTML**

--- a/opengraph/opengraph.py
+++ b/opengraph/opengraph.py
@@ -23,7 +23,7 @@ class OpenGraph(dict):
     """
     """
 
-    required_attrs = ['title', 'type', 'image', 'url', 'description']
+    required_attrs = ['title', 'type', 'image', 'url']
 
     def __init__(self, url=None, html=None, scrape=False, **kwargs):
         # If scrape == True, then will try to fetch missing attribtues

--- a/opengraph/test.py
+++ b/opengraph/test.py
@@ -28,6 +28,7 @@ class test(unittest.TestCase):
     def test_to_html(self):
         og = opengraph.OpenGraph(html=HTML)
         self.assertTrue(og.to_html())
+        self.assertTrue(og.is_valid())
 
     def test_to_json(self):
         og = opengraph.OpenGraph(url='https://www.youtube.com/watch?v=XAyNT2bTFuI')


### PR DESCRIPTION
Also fix the example.

Please note the example from the readme was not working

>>> HTML = """<html prefix="og: http://ogp.me/ns#">
... <head>
... <title>The Rock (1996)</title>
... <meta property="og:title" content="The Rock" />
... <meta property="og:type" content="video.movie" />
... <meta property="og:url" content="http://www.imdb.com/title/tt0117500/" />
... <meta property="og:image" content="http://ia.media-imdb.com/images/rock.jpg" />
... ...
... </head>
... ...
... </html>"""
>>> import opengraph
>>> movie = opengraph.OpenGraph()
>>> movie.parser(HTML)
>>> movie.is_valid()
False
>>> movie.required_attrs
['title', 'type', 'image', 'url', 'description']
>>> movie.required_attrs.pop(-1)
'description'
>>> movie.is_valid()
True