### PR TITLE
docs: fix simple typo, parsung -> parsing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Features
 
 * Use it as a python dict
 * Input and parsing from a specific url
-* Input and parsung from html previous extracted
+* Input and parsing from html previous extracted
 * HTML output
 * JSON output
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `parsing` rather than `parsung`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md